### PR TITLE
Add deprecation notices to Docs/ and update README links

### DIFF
--- a/Docs/1_Authentication.md
+++ b/Docs/1_Authentication.md
@@ -1,3 +1,5 @@
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/ios](https://www.courier.com/docs/sdk-libraries/ios/). The content below may be outdated.
+
 # Authentication
 
 Manages user credentials between app sessions.

--- a/Docs/2_Inbox.md
+++ b/Docs/2_Inbox.md
@@ -1,5 +1,7 @@
 <img width="1000" alt="inbox-banner" src="https://user-images.githubusercontent.com/6370613/232106969-a9b31065-0b81-4013-9e03-1f2d3b634ab7.png">
 
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/ios](https://www.courier.com/docs/sdk-libraries/ios/). The content below may be outdated.
+
 &emsp;
 
 # Courier Inbox

--- a/Docs/3_PushNotifications.md
+++ b/Docs/3_PushNotifications.md
@@ -1,5 +1,7 @@
 <img width="1000" alt="push-banner" src="https://user-images.githubusercontent.com/6370613/229574537-0d45260f-120a-4b88-80b0-59880860bb46.png">
 
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/ios](https://www.courier.com/docs/sdk-libraries/ios/). The content below may be outdated.
+
 &emsp;
 
 # Push Notifications

--- a/Docs/4_Preferences.md
+++ b/Docs/4_Preferences.md
@@ -1,5 +1,7 @@
 <img width="1000" alt="ios-preferences-banner" src="https://github.com/trycourier/courier-ios/assets/6370613/52414bb0-b546-4a29-8137-65ec8d9c410e">
 
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/ios](https://www.courier.com/docs/sdk-libraries/ios/). The content below may be outdated.
+
 # Courier Preferences
 
 In-app notification settings that allow your users to customize which of your notifications they receive. Allows you to build high quality, flexible preference settings very quickly.

--- a/Docs/5_Client.md
+++ b/Docs/5_Client.md
@@ -1,3 +1,5 @@
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/ios](https://www.courier.com/docs/sdk-libraries/ios/). The content below may be outdated.
+
 # `CourierClient`
 
 Base layer Courier API wrapper.

--- a/README.md
+++ b/README.md
@@ -113,12 +113,12 @@ These are all the available features of the SDK.
                 1
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-ios/blob/master/Docs/1_Authentication.md">
+                <a href="https://www.courier.com/docs/sdk-libraries/ios/#authentication">
                     <code>Authentication</code>
                 </a>
             </td>
             <td align="left">
-                Manages user credentials between app sessions. Required if you would like to use <a href="https://github.com/trycourier/courier-ios/blob/master/Docs/2_Inbox.md"><code>Inbox</code></a>, <a href="https://github.com/trycourier/courier-ios/blob/master/Docs/3_PushNotifications.md"><code>Push Notifications</code></a> and <a href="https://github.com/trycourier/courier-ios/blob/master/Docs/4_Preferences.md"><code>Preferences</code></a>.
+                Manages user credentials between app sessions. Required if you would like to use <a href="https://www.courier.com/docs/sdk-libraries/ios/#inbox"><code>Inbox</code></a>, <a href="https://www.courier.com/docs/sdk-libraries/ios/#push-notifications"><code>Push Notifications</code></a> and <a href="https://www.courier.com/docs/sdk-libraries/ios/#preferences"><code>Preferences</code></a>.
             </td>
         </tr>
         <tr width="600px">
@@ -126,7 +126,7 @@ These are all the available features of the SDK.
                 2
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-ios/blob/master/Docs/2_Inbox.md">
+                <a href="https://www.courier.com/docs/sdk-libraries/ios/#inbox">
                     <code>Inbox</code>
                 </a>
             </td>
@@ -139,7 +139,7 @@ These are all the available features of the SDK.
                 3
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-ios/blob/master/Docs/3_PushNotifications.md">
+                <a href="https://www.courier.com/docs/sdk-libraries/ios/#push-notifications">
                     <code>Push Notifications</code>
                 </a>
             </td>
@@ -152,7 +152,7 @@ These are all the available features of the SDK.
                 4
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-ios/blob/master/Docs/4_Preferences.md">
+                <a href="https://www.courier.com/docs/sdk-libraries/ios/#preferences">
                     <code>Preferences</code>
                 </a>
             </td>
@@ -165,7 +165,7 @@ These are all the available features of the SDK.
                 5
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-ios/blob/master/Docs/5_Client.md">
+                <a href="https://www.courier.com/docs/sdk-libraries/ios/#courierclient">
                     <code>CourierClient</code>
                 </a>
             </td>


### PR DESCRIPTION
## Summary

- Adds deprecation notices to all 5 files in `Docs/` pointing to the canonical Mintlify docs at courier.com/docs/sdk-libraries/ios/
- Updates the README "Getting Started" feature table to link to Mintlify instead of the GitHub Docs/ files