### PR TITLE
docs(agents): add Public API skill and conventions for AI assistants

### DIFF
--- a/.claude/rules/api-conventions.md
+++ b/.claude/rules/api-conventions.md
@@ -1,0 +1,37 @@
+# Courier Public API — Assistant Conventions
+
+Purpose
+
+- Provide stable, high-signal conventions for AI coding assistants interacting with Courier’s Public API from this repository.
+- Avoid drift by deferring to the canonical rules maintained in the backend repository.
+
+Source of truth
+
+- Canonical rules live in the backend repo:
+  - https://github.com/trycourier/backend/blob/master/.claude/rules/api-conventions.md
+  - https://github.com/trycourier/backend/blob/master/.claude/rules/api-deviations.md
+- If any statements here disagree with the backend, treat the backend as authoritative.
+
+General guidance
+
+- Always use HTTPS and JSON.
+- Authenticate with a Bearer token via the Authorization header.
+- Treat 429 and 5xx as retryable with exponential backoff and jitter; respect Retry-After when present.
+- Prefer idempotent operations when available; avoid blind retries on non-idempotent writes.
+- Log requestId and messageId fields when available to aid support and debugging.
+- Use ISO 8601 timestamps and UTC when constructing or parsing date-time values.
+
+SDK alignment
+
+- This repository is an SDK; it does not define server endpoints. When in doubt about response envelopes or pagination fields, consult the backend canonical rules or the live API reference:
+  - https://www.courier.com/docs/reference/
+
+Review checklist for API usage in this repo
+
+- [ ] Authorization header present on all API requests
+- [ ] Content-Type: application/json set on requests with bodies
+- [ ] 4xx/5xx/429 errors handled with clear messages; retries only when safe
+- [ ] Timeouts and network errors surface actionable context (no silent failures)
+- [ ] Pagination follows server-provided cursors when available
+- [ ] Identifiers (msg_, req_, brd_, etc.) treated as opaque strings (no client-side parsing)
+

--- a/.claude/rules/api-deviations.md
+++ b/.claude/rules/api-deviations.md
@@ -1,0 +1,16 @@
+# Courier Public API — Known Deviations (iOS SDK)
+
+Scope
+
+- Track any intentional, repository-specific deviations from the canonical API assistant rules.
+- If empty, no repo-specific deviations are known.
+
+Current deviations
+
+- None. This repository is an SDK and does not define or override server response shapes. It follows the canonical rules documented in the backend repository:
+  - https://github.com/trycourier/backend/blob/master/.claude/rules/api-conventions.md
+
+Maintenance
+
+- If a deviation is required (e.g., platform-specific retry budgets, timeout tuning), add a concise entry with rationale and affected components.
+

--- a/.claude/skills/apis/courier-public-api/SKILL.md
+++ b/.claude/skills/apis/courier-public-api/SKILL.md
@@ -1,0 +1,104 @@
+# Courier Public API — Reference Skill
+
+Summary
+
+- This skill gives AI coding agents a concise, copy-pastable reference to the Courier Public API that is useful across repositories. It includes authentication, common headers, representative endpoints with curl examples, typical response shapes, errors, and rate limiting behavior.
+- The canonical, exhaustive API documentation remains on the Courier developer docs. This skill is intentionally focused on the 80/20 tasks agents most often perform in code: sending, inspecting messages, managing brands/templates, and reading resources.
+
+Scope and usage
+
+- Audience: AI code assistants (Claude Code, Codex, etc.) working in Courier repositories.
+- Repos: Duplicated across backend and SDKs so assistants can find API context in-repo without leaving the project.
+- Source of truth: Prefer live docs for edge cases, new features, and full parameter coverage.
+
+Base URL and auth
+
+- Base URL: https://api.courier.com
+- Auth: Bearer token in the Authorization header.
+- Required headers:
+  - Authorization: Bearer <COURIER_AUTH_TOKEN>
+  - Content-Type: application/json
+
+Example: Send a message
+
+```bash
+curl -X POST "https://api.courier.com/send" \
+  -H "Authorization: Bearer $COURIER_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": {
+      "to": { "email": "user@example.com" },
+      "content": { "title": "Hello", "body": "World" },
+      "routing": { "method": "single", "channels": ["email"] }
+    }
+  }'
+```
+
+Typical 202 response
+
+```json
+{
+  "requestId": "req_1234567890",
+  "messageId": "msg_1234567890"
+}
+```
+
+Example: Get a message by ID
+
+```bash
+curl -X GET "https://api.courier.com/messages/msg_1234567890" \
+  -H "Authorization: Bearer $COURIER_AUTH_TOKEN" \
+  -H "Content-Type: application/json"
+```
+
+Example: List brands
+
+```bash
+curl -X GET "https://api.courier.com/brands" \
+  -H "Authorization: Bearer $COURIER_AUTH_TOKEN" \
+  -H "Content-Type: application/json"
+```
+
+Example: Create or update a profile
+
+```bash
+curl -X PUT "https://api.courier.com/profiles/user_123" \
+  -H "Authorization: Bearer $COURIER_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "user@example.com",
+    "phone_number": "+15555550123",
+    "tokens": { "fcm": "FCM_DEVICE_TOKEN" }
+  }'
+```
+
+Errors and rate limiting
+
+- 400: Validation error — check required fields and types
+- 401: Invalid or missing token — refresh credentials
+- 403: Insufficient scope/permissions
+- 404: Resource not found
+- 409: Conflict (e.g., duplicate resource)
+- 429: Too many requests — implement exponential backoff and retry after the Retry-After header
+- 5xx: Transient server errors — safe to retry with jitter
+
+Conventions and shapes
+
+- JSON request/response
+- Stable identifiers: prefixes like msg_, req_, brd_ are common
+- Timestamps: ISO 8601 strings
+- Pagination: cursor or page/limit depending on endpoint — prefer server-provided cursors when available
+
+References
+
+- Public API reference: https://www.courier.com/docs/reference/
+- Send API: https://www.courier.com/docs/reference/send
+- Brands API: https://www.courier.com/docs/reference/brands
+- Messages API: https://www.courier.com/docs/reference/messages
+
+Maintenance
+
+- This file is intentionally duplicated in multiple repos to improve agent discoverability.
+- Keep examples minimal, correct, and runnable. Prefer links over duplicating exhaustive parameter lists.
+- If conventions change, update the .claude/rules/api-conventions.md file in each repo and refresh links here.
+

--- a/.codex/skills/apis/courier-public-api/SKILL.md
+++ b/.codex/skills/apis/courier-public-api/SKILL.md
@@ -1,0 +1,104 @@
+# Courier Public API — Reference Skill
+
+Summary
+
+- This skill gives AI coding agents a concise, copy-pastable reference to the Courier Public API that is useful across repositories. It includes authentication, common headers, representative endpoints with curl examples, typical response shapes, errors, and rate limiting behavior.
+- The canonical, exhaustive API documentation remains on the Courier developer docs. This skill is intentionally focused on the 80/20 tasks agents most often perform in code: sending, inspecting messages, managing brands/templates, and reading resources.
+
+Scope and usage
+
+- Audience: AI code assistants (Claude Code, Codex, etc.) working in Courier repositories.
+- Repos: Duplicated across backend and SDKs so assistants can find API context in-repo without leaving the project.
+- Source of truth: Prefer live docs for edge cases, new features, and full parameter coverage.
+
+Base URL and auth
+
+- Base URL: https://api.courier.com
+- Auth: Bearer token in the Authorization header.
+- Required headers:
+  - Authorization: Bearer <COURIER_AUTH_TOKEN>
+  - Content-Type: application/json
+
+Example: Send a message
+
+```bash
+curl -X POST "https://api.courier.com/send" \
+  -H "Authorization: Bearer $COURIER_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": {
+      "to": { "email": "user@example.com" },
+      "content": { "title": "Hello", "body": "World" },
+      "routing": { "method": "single", "channels": ["email"] }
+    }
+  }'
+```
+
+Typical 202 response
+
+```json
+{
+  "requestId": "req_1234567890",
+  "messageId": "msg_1234567890"
+}
+```
+
+Example: Get a message by ID
+
+```bash
+curl -X GET "https://api.courier.com/messages/msg_1234567890" \
+  -H "Authorization: Bearer $COURIER_AUTH_TOKEN" \
+  -H "Content-Type: application/json"
+```
+
+Example: List brands
+
+```bash
+curl -X GET "https://api.courier.com/brands" \
+  -H "Authorization: Bearer $COURIER_AUTH_TOKEN" \
+  -H "Content-Type: application/json"
+```
+
+Example: Create or update a profile
+
+```bash
+curl -X PUT "https://api.courier.com/profiles/user_123" \
+  -H "Authorization: Bearer $COURIER_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "user@example.com",
+    "phone_number": "+15555550123",
+    "tokens": { "fcm": "FCM_DEVICE_TOKEN" }
+  }'
+```
+
+Errors and rate limiting
+
+- 400: Validation error — check required fields and types
+- 401: Invalid or missing token — refresh credentials
+- 403: Insufficient scope/permissions
+- 404: Resource not found
+- 409: Conflict (e.g., duplicate resource)
+- 429: Too many requests — implement exponential backoff and retry after the Retry-After header
+- 5xx: Transient server errors — safe to retry with jitter
+
+Conventions and shapes
+
+- JSON request/response
+- Stable identifiers: prefixes like msg_, req_, brd_ are common
+- Timestamps: ISO 8601 strings
+- Pagination: cursor or page/limit depending on endpoint — prefer server-provided cursors when available
+
+References
+
+- Public API reference: https://www.courier.com/docs/reference/
+- Send API: https://www.courier.com/docs/reference/send
+- Brands API: https://www.courier.com/docs/reference/brands
+- Messages API: https://www.courier.com/docs/reference/messages
+
+Maintenance
+
+- This file is intentionally duplicated in multiple repos to improve agent discoverability.
+- Keep examples minimal, correct, and runnable. Prefer links over duplicating exhaustive parameter lists.
+- If conventions change, update the .claude/rules/api-conventions.md file in each repo and refresh links here.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AI Agent Files (iOS SDK)
+
+Overview
+
+This repository includes metadata for AI coding assistants (e.g., Claude Code, Codex) to provide better autocomplete, context, and safe-by-default API usage. These files are intentionally lightweight and link to authoritative sources.
+
+Contents
+
+- Skills
+  - `.claude/skills/apis/courier-public-api/SKILL.md`
+  - `.codex/skills/apis/courier-public-api/SKILL.md`
+  - Purpose: quick, copy-pastable Public API reference with auth, common headers, representative endpoints, example requests, and links to docs.
+
+- Rules
+  - `.claude/rules/api-conventions.md` — assistant-facing conventions for interacting with Courier’s Public API from this repo.
+  - `.claude/rules/api-deviations.md` — repository-specific deviations (empty if none).
+
+Conventions
+
+- Canonical rules and any comprehensive API references are maintained in the backend repository and on the public docs:
+  - https://github.com/trycourier/backend
+  - https://www.courier.com/docs/reference/
+- Keep examples in this repo minimal and correct; prefer linking to live docs over duplicating exhaustive parameter tables.
+
+Discovery
+
+- Claude Code: skills under `.claude/skills/**/SKILL.md` and rules under `.claude/rules/*.md` are auto-indexed.
+- Codex: skills under `.codex/skills/**/SKILL.md` are used for auto-discovery in API-related contexts.
+
+Maintenance
+
+- If the backend rules change, mirror any necessary updates here.
+- If this SDK gains new capabilities that change API usage patterns (e.g., new endpoints surfaced), update skills/rules accordingly.
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Summary

- Adds concise Public API reference skill for AI agents: `.claude/skills/apis/courier-public-api/SKILL.md` and `.codex/skills/apis/courier-public-api/SKILL.md`
- Introduces assistant-facing API conventions and deviation tracker: `.claude/rules/api-conventions.md`, `.claude/rules/api-deviations.md`
- Adds `AGENTS.md` to document agent file locations, discovery, and maintenance

Notes

- This mirrors the backend "public API conventions in the agent folders" effort so assistants can discover consistent API context directly in the iOS SDK repo.
- The conventions file defers to the canonical backend rules; this keeps SDK guidance lightweight and avoids drift.

Test plan

- Verify Claude Code and Codex index files under `.claude/**` and `.codex/**`
- Open the new SKILL.md and spot-check curl examples (auth header, endpoint paths) against live docs
- Ensure no build or packaging changes are affected (docs-only)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://trycourier.slack.com/archives/CLQ9S7U23/p1775676543151369?thread_ts=1775676543.151369&cid=CLQ9S7U23)

<div><a href="https://cursor.com/agents/bc-47493258-e8b1-4fe4-869e-7a4e29e9e803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47493258-e8b1-4fe4-869e-7a4e29e9e803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

