### PR TITLE
Fix downstream bump job: configure git for GitHub App token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,6 +99,12 @@ jobs:
           owner: trycourier
           repositories: courier-flutter,courier-react-native
 
+      # gh repo clone uses GH_TOKEN; git push does not unless git is configured.
+      - name: Configure git for HTTPS with app token
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh auth setup-git
+
       - name: Bump courier-flutter
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Problem

The **Bump Downstream Dependencies** job failed on `git push` with:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

`gh repo clone` uses `GH_TOKEN`, but plain `git push` does not unless Git's credential helper is wired to that token.

## Change

Add a step after **Generate GitHub App token** that runs `gh auth setup-git` with `GH_TOKEN` set to the app installation token so HTTPS `git push` works on the runner.

## Ref

Failed run: downstream bump after merge of CI automation (courier-flutter push step).

Made with [Cursor](https://cursor.com)