### PR TITLE
Add customizable inbox and preferences render hooks

### DIFF
--- a/Sources/Courier_iOS/UI/Inbox/CourierInbox.swift
+++ b/Sources/Courier_iOS/UI/Inbox/CourierInbox.swift
@@ -10,6 +10,13 @@ import UIKit
 @available(iOSApplicationExtension, unavailable)
 open class CourierInbox: UIView, UIScrollViewDelegate {
     
+    public typealias CustomTabItemView = (_ feed: InboxMessageFeed, _ title: String, _ isSelected: Bool, _ unreadCount: Int?) -> UIView
+    public typealias CustomListItemView = (_ message: InboxMessage, _ index: Int) -> UIView
+    public typealias CustomLoadingStateView = (_ feed: InboxMessageFeed) -> UIView
+    public typealias CustomEmptyStateView = (_ feed: InboxMessageFeed, _ onRetry: @escaping () -> Void) -> UIView
+    public typealias CustomErrorStateView = (_ feed: InboxMessageFeed, _ message: String, _ onRetry: @escaping () -> Void) -> UIView
+    public typealias CustomPaginationItemView = (_ feed: InboxMessageFeed) -> UIView
+    
     // MARK: Interaction
     
     private let canSwipePages: Bool
@@ -21,6 +28,15 @@ open class CourierInbox: UIView, UIScrollViewDelegate {
     private var darkTheme: CourierInboxTheme
 
     private var theme: CourierInboxTheme = .defaultLight
+    
+    // MARK: Custom Views
+    
+    private let customTabItem: CustomTabItemView?
+    private let customListItem: CustomListItemView?
+    private let customLoadingState: CustomLoadingStateView?
+    private let customEmptyState: CustomEmptyStateView?
+    private let customErrorState: CustomErrorStateView?
+    private let customPaginationItem: CustomPaginationItemView?
     
     // MARK: Interaction
     
@@ -42,6 +58,7 @@ open class CourierInbox: UIView, UIScrollViewDelegate {
     
     private lazy var messagesPage = {
         return Page(
+            feed: .feed,
             title: "Notifications",
             page: makeInboxList(.feed)
         )
@@ -49,6 +66,7 @@ open class CourierInbox: UIView, UIScrollViewDelegate {
     
     private lazy var archivedPage = {
         return Page(
+            feed: .archive,
             title: "Archived",
             page: makeInboxList(.archive)
         )
@@ -66,6 +84,7 @@ open class CourierInbox: UIView, UIScrollViewDelegate {
         let tabs = TabView(
             pages: getPages(),
             scrollView: scrollView,
+            customTabItem: customTabItem,
             onTabSelected: { [weak self] index in
                 self?.updateScrollViewToPage(index)
             },
@@ -113,6 +132,12 @@ open class CourierInbox: UIView, UIScrollViewDelegate {
         pagingDuration: TimeInterval = 0.1,
         lightTheme: CourierInboxTheme = .defaultLight,
         darkTheme: CourierInboxTheme = .defaultDark,
+        customTabItem: CustomTabItemView? = nil,
+        customListItem: CustomListItemView? = nil,
+        customLoadingState: CustomLoadingStateView? = nil,
+        customEmptyState: CustomEmptyStateView? = nil,
+        customErrorState: CustomErrorStateView? = nil,
+        customPaginationItem: CustomPaginationItemView? = nil,
         didClickInboxMessageAtIndex: ((_ message: InboxMessage, _ index: Int) -> Void)? = nil,
         didLongPressInboxMessageAtIndex: ((_ message: InboxMessage, _ index: Int) -> Void)? = nil,
         didClickInboxActionForMessageAtIndex: ((InboxAction, InboxMessage, Int) -> Void)? = nil,
@@ -125,6 +150,12 @@ open class CourierInbox: UIView, UIScrollViewDelegate {
         
         self.lightTheme = lightTheme
         self.darkTheme = darkTheme
+        self.customTabItem = customTabItem
+        self.customListItem = customListItem
+        self.customLoadingState = customLoadingState
+        self.customEmptyState = customEmptyState
+        self.customErrorState = customErrorState
+        self.customPaginationItem = customPaginationItem
         
         super.init(frame: .zero)
         
@@ -142,6 +173,12 @@ open class CourierInbox: UIView, UIScrollViewDelegate {
         self.pagingDuration = 0.1
         self.lightTheme = .defaultLight
         self.darkTheme = .defaultDark
+        self.customTabItem = nil
+        self.customListItem = nil
+        self.customLoadingState = nil
+        self.customEmptyState = nil
+        self.customErrorState = nil
+        self.customPaginationItem = nil
         super.init(frame: frame)
         setup()
     }
@@ -151,6 +188,12 @@ open class CourierInbox: UIView, UIScrollViewDelegate {
         self.pagingDuration = 0.1
         self.lightTheme = .defaultLight
         self.darkTheme = .defaultDark
+        self.customTabItem = nil
+        self.customListItem = nil
+        self.customLoadingState = nil
+        self.customEmptyState = nil
+        self.customErrorState = nil
+        self.customPaginationItem = nil
         super.init(coder: coder)
         setup()
     }
@@ -248,6 +291,11 @@ open class CourierInbox: UIView, UIScrollViewDelegate {
     private func makeInboxList(_ feed: InboxMessageFeed) -> InboxMessageListView {
         let list = InboxMessageListView(
             feed: feed,
+            customListItem: customListItem,
+            customLoadingState: customLoadingState,
+            customEmptyState: customEmptyState,
+            customErrorState: customErrorState,
+            customPaginationItem: customPaginationItem,
             didClickInboxMessageAtIndex: { [weak self] message, index in
                 self?.didClickInboxMessageAtIndex?(message, index)
             },

--- a/Sources/Courier_iOS/UI/Inbox/CourierInboxView.swift
+++ b/Sources/Courier_iOS/UI/Inbox/CourierInboxView.swift
@@ -1,6 +1,6 @@
 //
 //  CourierInboxView.swift
-//  
+//
 //
 //  Created by https://github.com/mikemilla on 3/27/23.
 //
@@ -10,6 +10,8 @@ import SwiftUI
 @available(iOSApplicationExtension, unavailable)
 public struct CourierInboxView: UIViewRepresentable {
     
+    public typealias UIViewType = CourierInbox
+    
     private let inbox: CourierInbox
     
     public init(
@@ -17,6 +19,12 @@ public struct CourierInboxView: UIViewRepresentable {
         pagingDuration: TimeInterval = 0.1,
         lightTheme: CourierInboxTheme = .defaultLight,
         darkTheme: CourierInboxTheme = .defaultDark,
+        customTabItem: CourierInbox.CustomTabItemView? = nil,
+        customListItem: CourierInbox.CustomListItemView? = nil,
+        customLoadingState: CourierInbox.CustomLoadingStateView? = nil,
+        customEmptyState: CourierInbox.CustomEmptyStateView? = nil,
+        customErrorState: CourierInbox.CustomErrorStateView? = nil,
+        customPaginationItem: CourierInbox.CustomPaginationItemView? = nil,
         didClickInboxMessageAtIndex: ((_ message: InboxMessage, _ index: Int) -> Void)? = nil,
         didLongPressInboxMessageAtIndex: ((_ message: InboxMessage, _ index: Int) -> Void)? = nil,
         didClickInboxActionForMessageAtIndex: ((InboxAction, InboxMessage, Int) -> Void)? = nil,
@@ -28,6 +36,12 @@ public struct CourierInboxView: UIViewRepresentable {
             pagingDuration: pagingDuration,
             lightTheme: lightTheme,
             darkTheme: darkTheme,
+            customTabItem: customTabItem,
+            customListItem: customListItem,
+            customLoadingState: customLoadingState,
+            customEmptyState: customEmptyState,
+            customErrorState: customErrorState,
+            customPaginationItem: customPaginationItem,
             didClickInboxMessageAtIndex: didClickInboxMessageAtIndex,
             didLongPressInboxMessageAtIndex: didLongPressInboxMessageAtIndex,
             didClickInboxActionForMessageAtIndex: didClickInboxActionForMessageAtIndex,
@@ -36,12 +50,129 @@ public struct CourierInboxView: UIViewRepresentable {
         )
     }
     
-    public func makeUIView(context: Context) -> some UIView {
+    public func makeUIView(context: Context) -> CourierInbox {
         return inbox
     }
     
     public func updateUIView(_ uiView: UIViewType, context: Context) {
         // Empty
     }
+}
+
+@available(iOSApplicationExtension, unavailable)
+public extension CourierInboxView {
     
+    struct SwiftUICustomViews {
+        public let tabItem: ((_ feed: InboxMessageFeed, _ title: String, _ isSelected: Bool, _ unreadCount: Int?) -> AnyView)?
+        public let listItem: ((_ message: InboxMessage, _ index: Int) -> AnyView)?
+        public let loadingState: ((_ feed: InboxMessageFeed) -> AnyView)?
+        public let emptyState: ((_ feed: InboxMessageFeed, _ onRetry: @escaping () -> Void) -> AnyView)?
+        public let errorState: ((_ feed: InboxMessageFeed, _ message: String, _ onRetry: @escaping () -> Void) -> AnyView)?
+        public let paginationItem: ((_ feed: InboxMessageFeed) -> AnyView)?
+        
+        public init(
+            tabItem: ((_ feed: InboxMessageFeed, _ title: String, _ isSelected: Bool, _ unreadCount: Int?) -> AnyView)? = nil,
+            listItem: ((_ message: InboxMessage, _ index: Int) -> AnyView)? = nil,
+            loadingState: ((_ feed: InboxMessageFeed) -> AnyView)? = nil,
+            emptyState: ((_ feed: InboxMessageFeed, _ onRetry: @escaping () -> Void) -> AnyView)? = nil,
+            errorState: ((_ feed: InboxMessageFeed, _ message: String, _ onRetry: @escaping () -> Void) -> AnyView)? = nil,
+            paginationItem: ((_ feed: InboxMessageFeed) -> AnyView)? = nil
+        ) {
+            self.tabItem = tabItem
+            self.listItem = listItem
+            self.loadingState = loadingState
+            self.emptyState = emptyState
+            self.errorState = errorState
+            self.paginationItem = paginationItem
+        }
+    }
+    
+    private static func host<Content: View>(_ view: Content) -> UIView {
+        let host = UIHostingController(rootView: view)
+        host.view.backgroundColor = .clear
+        return host.view
+    }
+    
+    init(
+        canSwipePages: Bool = false,
+        pagingDuration: TimeInterval = 0.1,
+        lightTheme: CourierInboxTheme = .defaultLight,
+        darkTheme: CourierInboxTheme = .defaultDark,
+        swiftUICustomViews: SwiftUICustomViews,
+        didClickInboxMessageAtIndex: ((_ message: InboxMessage, _ index: Int) -> Void)? = nil,
+        didLongPressInboxMessageAtIndex: ((_ message: InboxMessage, _ index: Int) -> Void)? = nil,
+        didClickInboxActionForMessageAtIndex: ((InboxAction, InboxMessage, Int) -> Void)? = nil,
+        didScrollInbox: ((UIScrollView) -> Void)? = nil,
+        onError: ((CourierError) -> String)? = nil
+    ) {
+        self.init(
+            canSwipePages: canSwipePages,
+            pagingDuration: pagingDuration,
+            lightTheme: lightTheme,
+            darkTheme: darkTheme,
+            customTabItem: swiftUICustomViews.tabItem.map { render in
+                { feed, title, isSelected, unreadCount in
+                    CourierInboxView.host(render(feed, title, isSelected, unreadCount))
+                }
+            },
+            customListItem: swiftUICustomViews.listItem.map { render in
+                { message, index in
+                    CourierInboxView.host(render(message, index))
+                }
+            },
+            customLoadingState: swiftUICustomViews.loadingState.map { render in
+                { feed in
+                    CourierInboxView.host(render(feed))
+                }
+            },
+            customEmptyState: swiftUICustomViews.emptyState.map { render in
+                { feed, onRetry in
+                    CourierInboxView.host(render(feed, onRetry))
+                }
+            },
+            customErrorState: swiftUICustomViews.errorState.map { render in
+                { feed, message, onRetry in
+                    CourierInboxView.host(render(feed, message, onRetry))
+                }
+            },
+            customPaginationItem: swiftUICustomViews.paginationItem.map { render in
+                { feed in
+                    CourierInboxView.host(render(feed))
+                }
+            },
+            didClickInboxMessageAtIndex: didClickInboxMessageAtIndex,
+            didLongPressInboxMessageAtIndex: didLongPressInboxMessageAtIndex,
+            didClickInboxActionForMessageAtIndex: didClickInboxActionForMessageAtIndex,
+            didScrollInbox: didScrollInbox,
+            onError: onError
+        )
+    }
+    
+    init<CustomListItem: View>(
+        canSwipePages: Bool = false,
+        pagingDuration: TimeInterval = 0.1,
+        lightTheme: CourierInboxTheme = .defaultLight,
+        darkTheme: CourierInboxTheme = .defaultDark,
+        didClickInboxMessageAtIndex: ((_ message: InboxMessage, _ index: Int) -> Void)? = nil,
+        didLongPressInboxMessageAtIndex: ((_ message: InboxMessage, _ index: Int) -> Void)? = nil,
+        didClickInboxActionForMessageAtIndex: ((InboxAction, InboxMessage, Int) -> Void)? = nil,
+        didScrollInbox: ((UIScrollView) -> Void)? = nil,
+        onError: ((CourierError) -> String)? = nil,
+        @ViewBuilder customListItem: @escaping (_ message: InboxMessage, _ index: Int) -> CustomListItem
+    ) {
+        self.init(
+            canSwipePages: canSwipePages,
+            pagingDuration: pagingDuration,
+            lightTheme: lightTheme,
+            darkTheme: darkTheme,
+            customListItem: { message, index in
+                CourierInboxView.host(customListItem(message, index))
+            },
+            didClickInboxMessageAtIndex: didClickInboxMessageAtIndex,
+            didLongPressInboxMessageAtIndex: didLongPressInboxMessageAtIndex,
+            didClickInboxActionForMessageAtIndex: didClickInboxActionForMessageAtIndex,
+            didScrollInbox: didScrollInbox,
+            onError: onError
+        )
+    }
 }

--- a/Sources/Courier_iOS/UI/Inbox/InboxMessageListView.swift
+++ b/Sources/Courier_iOS/UI/Inbox/InboxMessageListView.swift
@@ -10,11 +10,23 @@ import UIKit
 @available(iOSApplicationExtension, unavailable)
 internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDataSource {
     
+    private static let customListItemId = "CustomInboxListItem"
+    private static let customPaginationItemId = "CustomInboxPaginationItem"
+    
     private let feed: InboxMessageFeed
     
     // MARK: Theme
-
+    
     private var theme: CourierInboxTheme = .defaultLight
+    
+    // MARK: Custom Views
+    
+    private let customListItem: CourierInbox.CustomListItemView?
+    private let customLoadingState: CourierInbox.CustomLoadingStateView?
+    private let customEmptyState: CourierInbox.CustomEmptyStateView?
+    private let customErrorState: CourierInbox.CustomErrorStateView?
+    private let customPaginationItem: CourierInbox.CustomPaginationItemView?
+    private var activeStateView: UIView? = nil
     
     // MARK: Interaction
     
@@ -40,6 +52,12 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
         tableView.backgroundColor = .systemBackground
         tableView.delegate = self
         tableView.dataSource = self
+        if customListItem != nil {
+            tableView.register(UITableViewCell.self, forCellReuseIdentifier: InboxMessageListView.customListItemId)
+        }
+        if customPaginationItem != nil {
+            tableView.register(UITableViewCell.self, forCellReuseIdentifier: InboxMessageListView.customPaginationItemId)
+        }
         tableView.register(CourierInboxTableViewCell.self, forCellReuseIdentifier: CourierInboxTableViewCell.id)
         tableView.register(CourierInboxPaginationCell.self, forCellReuseIdentifier: CourierInboxPaginationCell.id)
         tableView.rowHeight = UITableView.automaticDimension
@@ -54,8 +72,7 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
         let view = CourierInfoView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.onButtonClick = { [weak self] in
-            self?.state = .loading
-            self?.onRefresh()
+            self?.retry()
         }
         return view
     }()
@@ -67,6 +84,13 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
         return indicator
     }()
     
+    private lazy var stateContainer: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.isHidden = true
+        return view
+    }()
+    
     // MARK: Authentication
     
     private var authListener: CourierAuthenticationListener? = nil
@@ -74,36 +98,62 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
     // MARK: State
     
     private var isEmptyState: Bool {
-        get {
-            switch (state) {
-            case .empty: return true
-            default: return false
-            }
+        switch state {
+        case .empty: return true
+        default: return false
         }
     }
     
     private var state: State = .loading {
         didSet {
-            // Update UI
-            switch (state) {
+            switch state {
             case .loading:
-                self.loadingIndicator.startAnimating()
-                self.tableView.isHidden = true
-                self.infoView.isHidden = true
-            case .error:
-                self.loadingIndicator.stopAnimating()
-                self.tableView.isHidden = true
-                self.infoView.isHidden = false
-                self.infoView.updateView(state, actionTitle: "Retry", contentTitle: "No messages found")
+                if let customLoadingState = customLoadingState {
+                    loadingIndicator.stopAnimating()
+                    tableView.isHidden = true
+                    infoView.isHidden = true
+                    showStateView(customLoadingState(feed))
+                } else {
+                    hideStateView()
+                    loadingIndicator.startAnimating()
+                    tableView.isHidden = true
+                    infoView.isHidden = true
+                }
+            case .error(let message):
+                if let customErrorState = customErrorState {
+                    loadingIndicator.stopAnimating()
+                    tableView.isHidden = true
+                    infoView.isHidden = true
+                    showStateView(customErrorState(feed, message, { [weak self] in
+                        self?.retry()
+                    }))
+                } else {
+                    hideStateView()
+                    loadingIndicator.stopAnimating()
+                    tableView.isHidden = true
+                    infoView.isHidden = false
+                    infoView.updateView(state, actionTitle: "Retry", contentTitle: "No messages found")
+                }
             case .content:
-                self.loadingIndicator.stopAnimating()
-                self.tableView.isHidden = false
-                self.infoView.isHidden = true
+                hideStateView()
+                loadingIndicator.stopAnimating()
+                tableView.isHidden = false
+                infoView.isHidden = true
             case .empty:
-                self.loadingIndicator.stopAnimating()
-                self.tableView.isHidden = false
-                self.infoView.isHidden = false
-                self.infoView.updateView(state, actionTitle: "Retry", contentTitle: "No messages found")
+                if let customEmptyState = customEmptyState {
+                    loadingIndicator.stopAnimating()
+                    tableView.isHidden = true
+                    infoView.isHidden = true
+                    showStateView(customEmptyState(feed, { [weak self] in
+                        self?.retry()
+                    }))
+                } else {
+                    hideStateView()
+                    loadingIndicator.stopAnimating()
+                    tableView.isHidden = false
+                    infoView.isHidden = false
+                    infoView.updateView(state, actionTitle: "Retry", contentTitle: "No messages found")
+                }
             }
         }
     }
@@ -112,12 +162,22 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
     
     public init(
         feed: InboxMessageFeed,
+        customListItem: CourierInbox.CustomListItemView? = nil,
+        customLoadingState: CourierInbox.CustomLoadingStateView? = nil,
+        customEmptyState: CourierInbox.CustomEmptyStateView? = nil,
+        customErrorState: CourierInbox.CustomErrorStateView? = nil,
+        customPaginationItem: CourierInbox.CustomPaginationItemView? = nil,
         didClickInboxMessageAtIndex: @escaping (_ message: InboxMessage, _ index: Int) -> Void,
         didLongPressInboxMessageAtIndex: @escaping (_ message: InboxMessage, _ index: Int) -> Void,
         didClickInboxActionForMessageAtIndex: @escaping (_ action: InboxAction, _ message: InboxMessage, _ index: Int) -> Void,
         didScrollInbox: @escaping (UIScrollView) -> Void
     ) {
         self.feed = feed
+        self.customListItem = customListItem
+        self.customLoadingState = customLoadingState
+        self.customEmptyState = customEmptyState
+        self.customErrorState = customErrorState
+        self.customPaginationItem = customPaginationItem
         self.didClickInboxMessageAtIndex = didClickInboxMessageAtIndex
         self.didLongPressInboxMessageAtIndex = didLongPressInboxMessageAtIndex
         self.didClickInboxActionForMessageAtIndex = didClickInboxActionForMessageAtIndex
@@ -125,9 +185,14 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
         super.init(frame: .zero)
         setup()
     }
-
+    
     override init(frame: CGRect) {
         self.feed = .feed
+        self.customListItem = nil
+        self.customLoadingState = nil
+        self.customEmptyState = nil
+        self.customErrorState = nil
+        self.customPaginationItem = nil
         self.didClickInboxMessageAtIndex = { _, _ in }
         self.didLongPressInboxMessageAtIndex = { _, _ in }
         self.didClickInboxActionForMessageAtIndex = { _, _, _ in }
@@ -138,6 +203,11 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
     
     public required init?(coder: NSCoder) {
         self.feed = .feed
+        self.customListItem = nil
+        self.customLoadingState = nil
+        self.customEmptyState = nil
+        self.customErrorState = nil
+        self.customPaginationItem = nil
         self.didClickInboxMessageAtIndex = { _, _ in }
         self.didLongPressInboxMessageAtIndex = { _, _ in }
         self.didClickInboxActionForMessageAtIndex = { _, _, _ in }
@@ -147,7 +217,6 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
     }
     
     private func setup() {
-        
         Task {
             authListener = await Courier.shared.addAuthenticationListener { [weak self] userId in
                 if (userId != nil) {
@@ -158,17 +227,17 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
             }
         }
         
-        // Set state
         state = .loading
-
-        // Add the views
         addTableView()
         addLoadingIndicator()
         addInfoView()
-        
-        // Refreshes theme
+        addStateContainer()
         traitCollectionDidChange(nil)
-        
+    }
+    
+    private func retry() {
+        state = .loading
+        onRefresh()
     }
     
     internal func setTheme(_ theme: CourierInboxTheme) {
@@ -195,7 +264,6 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
     }
     
     internal func addPage(messages: [InboxMessage], canPaginate: Bool) {
-        
         self.manuallyArchivedMessageId = nil
         
         if messages.isEmpty {
@@ -212,10 +280,8 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
             IndexPath(row: $0, section: 0)
         }
         
-        // Add items to the table
         self.tableView.insertRows(at: indexPaths, with: .automatic)
         
-        // Remove the reload cell
         let couldPaginate = self.canPaginate
         self.canPaginate = canPaginate
         if couldPaginate && !canPaginate {
@@ -223,24 +289,18 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
         }
         
         self.openVisibleMessages()
-        
     }
     
     internal func addMessage(at index: Int, message: InboxMessage) {
-        
-        // Ensure the index is within bounds for insertion
         guard index >= 0 && index <= inboxMessages.count else {
             print("Error: Index \(index) is out of bounds for inboxMessages.")
             return
         }
-
+        
         self.manuallyArchivedMessageId = nil
-        self.inboxMessages.insert(message, at: index) // Safe insertion
-
-        // Update the state based on inboxMessages' contents
+        self.inboxMessages.insert(message, at: index)
         self.state = inboxMessages.isEmpty ? .empty : .content
-
-        // Ensure the indexPath is valid for the tableView
+        
         guard index >= 0 && index <= tableView.numberOfRows(inSection: 0) else {
             Task {
                 await Courier.shared.client?.log("Error: CourierInboxListView index \(index) is out of bounds.")
@@ -249,53 +309,47 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
             self.state = self.inboxMessages.isEmpty ? .empty : .content
             return
         }
-
-        let indexPath = IndexPath(row: index, section: 0)
-        self.tableView.insertRows(at: [indexPath], with: theme.messageAnimationStyle) // Safe table view update
-        self.openVisibleMessages() // Additional logic
         
+        let indexPath = IndexPath(row: index, section: 0)
+        self.tableView.insertRows(at: [indexPath], with: theme.messageAnimationStyle)
+        self.openVisibleMessages()
     }
     
     internal func updateMessage(at index: Int, message: InboxMessage) {
-        
         if !canUpdateMessages(index: index, messageId: message.messageId) {
             return
         }
         
         self.inboxMessages[index] = message
         self.state = inboxMessages.isEmpty ? .empty : .content
-
-        // Refresh the cell
-        let indexPath = IndexPath(row: index, section: 0)
-        let cell = tableView.cellForRow(at: indexPath) as? CourierInboxTableViewCell
-        cell?.refreshMessage(message)
         
+        let indexPath = IndexPath(row: index, section: 0)
+        if self.customListItem != nil {
+            tableView.reloadRows(at: [indexPath], with: .automatic)
+        } else {
+            let cell = tableView.cellForRow(at: indexPath) as? CourierInboxTableViewCell
+            cell?.refreshMessage(message)
+        }
     }
     
     internal func removeMessage(at index: Int, message: InboxMessage) {
-        
-        // Check if index is within bounds and if the message matches
         guard index >= 0 && index < inboxMessages.count, inboxMessages[index].messageId == message.messageId else {
             print("Invalid index or message ID mismatch. Cannot remove message.")
             return
         }
         
-        // Proceed if canUpdateMessages allows it
         if !canUpdateMessages(index: index, messageId: message.messageId) {
             return
         }
-
-        // Remove the message from the data source first
+        
         inboxMessages.remove(at: index)
         
-        // React Native Bug fix... weird.
         if (Courier.agent.isReactNative()) {
             self.tableView.reloadData()
             self.state = self.inboxMessages.isEmpty ? .empty : .content
             return
         }
         
-        // Then, update the UI with the deletion
         let indexPath = IndexPath(row: index, section: 0)
         tableView.performBatchUpdates({
             self.tableView.deleteRows(at: [indexPath], with: .left)
@@ -304,11 +358,9 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
                 self.state = self.inboxMessages.isEmpty ? .empty : .content
             }
         })
-        
     }
     
     private func canUpdateMessages(index: Int, messageId: String) -> Bool {
-        
         if manuallyArchivedMessageId == messageId {
             return false
         }
@@ -326,7 +378,6 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
         }
         
         return true
-        
     }
     
     private func addTableView() {
@@ -359,6 +410,50 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
         ])
     }
     
+    private func addStateContainer() {
+        addSubview(stateContainer)
+        
+        NSLayoutConstraint.activate([
+            stateContainer.topAnchor.constraint(equalTo: topAnchor),
+            stateContainer.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stateContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stateContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+    }
+    
+    private func showStateView(_ view: UIView) {
+        activeStateView?.removeFromSuperview()
+        activeStateView = view
+        view.translatesAutoresizingMaskIntoConstraints = false
+        stateContainer.isHidden = false
+        stateContainer.addSubview(view)
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: stateContainer.topAnchor),
+            view.bottomAnchor.constraint(equalTo: stateContainer.bottomAnchor),
+            view.leadingAnchor.constraint(equalTo: stateContainer.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: stateContainer.trailingAnchor),
+        ])
+    }
+    
+    private func hideStateView() {
+        activeStateView?.removeFromSuperview()
+        activeStateView = nil
+        stateContainer.isHidden = true
+    }
+    
+    private func renderCustomView(in cell: UITableViewCell, view: UIView, selectionStyle: UITableViewCell.SelectionStyle = .none) {
+        cell.selectionStyle = selectionStyle
+        cell.contentView.subviews.forEach { $0.removeFromSuperview() }
+        view.translatesAutoresizingMaskIntoConstraints = false
+        cell.contentView.addSubview(view)
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: cell.contentView.topAnchor),
+            view.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor),
+            view.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor),
+        ])
+    }
+    
     @objc private func onRefresh() {
         Task {
             await rootInbox?.refreshBrand()
@@ -375,13 +470,17 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
     }
     
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if (indexPath.section == 0) {
+        if indexPath.section == 0 {
+            let index = indexPath.row
+            let message = inboxMessages[index]
+            
+            if let customListItem = self.customListItem {
+                let cell = tableView.dequeueReusableCell(withIdentifier: InboxMessageListView.customListItemId, for: indexPath)
+                renderCustomView(in: cell, view: customListItem(message, index))
+                return cell
+            }
             
             if let cell = tableView.dequeueReusableCell(withIdentifier: CourierInboxTableViewCell.id, for: indexPath) as? CourierInboxTableViewCell {
-                
-                let index = indexPath.row
-                let message = inboxMessages[index]
-                
                 cell.setMessage(message, theme,
                     onActionClick: { [weak self] inboxAction in
                         self?.didClickInboxActionForMessageAtIndex(
@@ -396,12 +495,15 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
                         }
                     }
                 )
-                
+                return cell
+            }
+        } else {
+            if let customPaginationItem = self.customPaginationItem {
+                let cell = tableView.dequeueReusableCell(withIdentifier: InboxMessageListView.customPaginationItemId, for: indexPath)
+                renderCustomView(in: cell, view: customPaginationItem(feed))
                 return cell
             }
             
-        } else {
-            // Pagination cell
             if let cell = tableView.dequeueReusableCell(withIdentifier: CourierInboxPaginationCell.id, for: indexPath) as? CourierInboxPaginationCell {
                 cell.setTheme(theme)
                 return cell
@@ -423,7 +525,7 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
         if let messageCell = cell as? CourierInboxTableViewCell {
             messageCell.applyListItemBackgroundColor(theme.listItemBackgroundColor)
         }
-        if (indexPath.section == 1 && self.canPaginate) {
+        if indexPath.section == 1 && self.canPaginate {
             Task {
                 do {
                     try await Courier.shared.fetchNextInboxPage(self.feed)
@@ -435,33 +537,20 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
     }
     
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if (indexPath.section == 0) {
-            
-            // Click the cell
+        if indexPath.section == 0 {
             let index = indexPath.row
             let message = self.inboxMessages[index]
-            
-            // Track the click
             message.markAsClicked()
-            
-            // Hit callback
             self.didClickInboxMessageAtIndex(message, index)
-            
-            // Deselect the row
             tableView.deselectRow(at: indexPath, animated: true)
-            
         }
     }
     
     private var manuallyArchivedMessageId: String? = nil
     
     private func archiveCell(at index: Int) {
-        
         let message = inboxMessages[index]
-        
         removeMessage(at: index, message: message)
-        
-        // Hold the message id
         self.manuallyArchivedMessageId = message.messageId
         
         Task {
@@ -471,11 +560,9 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
                 await Courier.shared.client?.log(error.localizedDescription)
             }
         }
-        
     }
     
     private func readCell(isRead: Bool, at index: Int) {
-
         let message = inboxMessages[index]
         
         Task {
@@ -489,65 +576,52 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
                 await Courier.shared.client?.log(error.localizedDescription)
             }
         }
-        
     }
     
-    // Reading handler
     public func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        
         let message = inboxMessages[indexPath.row]
         
-        if (self.canSwipePages || message.isArchived) {
+        if self.canSwipePages || message.isArchived || self.customListItem != nil {
             return nil
         }
         
         let style = message.isRead ? self.theme.readingSwipeActionStyle.read : self.theme.readingSwipeActionStyle.unread
         let actionTitle = message.isRead ? "Unread" : "Read"
-
-        let toggleReadAction = UIContextualAction(style: .normal, title: actionTitle) { [weak self] (action, view, completionHandler) in
+        
+        let toggleReadAction = UIContextualAction(style: .normal, title: actionTitle) { [weak self] (_, _, completionHandler) in
             tableView.deselectRow(at: indexPath, animated: true)
             self?.readCell(isRead: message.isRead, at: indexPath.row)
             completionHandler(true)
         }
         
-        // Customize the appearance of the action
         toggleReadAction.backgroundColor = style.color
         toggleReadAction.image = style.icon
         
-        // Create a configuration object with the action
         let swipeConfiguration = UISwipeActionsConfiguration(actions: [toggleReadAction])
         swipeConfiguration.performsFirstActionWithFullSwipe = true
-        
         return swipeConfiguration
-        
     }
     
-    // Archiving handler
     public func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        
         let message = inboxMessages[indexPath.row]
         
-        if (self.canSwipePages || message.isArchived) {
+        if self.canSwipePages || message.isArchived || self.customListItem != nil {
             return nil
         }
         
-        let archiveAction = UIContextualAction(style: .destructive, title: "Archive") { [weak self] (action, view, completionHandler) in
+        let archiveAction = UIContextualAction(style: .destructive, title: "Archive") { [weak self] (_, _, completionHandler) in
             tableView.deselectRow(at: indexPath, animated: true)
             self?.archiveCell(at: indexPath.row)
             completionHandler(true)
         }
         
-        // Customize the action appearance
         let style = self.theme.archivingSwipeActionStyle.archive
         archiveAction.backgroundColor = style.color
         archiveAction.image = style.icon
         
-        // Create a configuration object with the action
         let swipeConfiguration = UISwipeActionsConfiguration(actions: [archiveAction])
         swipeConfiguration.performsFirstActionWithFullSwipe = true
-        
         return swipeConfiguration
-        
     }
     
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
@@ -563,7 +637,7 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
             return message.isOpened ? nil : message
         }
     }
-
+    
     private func openVisibleMessages() {
         guard let visibleIndexPaths = tableView.indexPathsForVisibleRows else { return }
         Task { @CourierActor in
@@ -576,13 +650,11 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
     }
     
     public func scrollToTop(animated: Bool) {
-        
-        if (self.inboxMessages.isEmpty) {
+        if self.inboxMessages.isEmpty {
             return
         }
         
         let indexPath = IndexPath(row: 0, section: 0)
-
         guard indexPath.row < self.inboxMessages.count else {
             return
         }
@@ -592,32 +664,33 @@ internal class InboxMessageListView: UIView, UITableViewDelegate, UITableViewDat
             at: .top,
             animated: animated
         )
-        
     }
     
     private func reloadViews() {
         self.backgroundColor = theme.backgroundColor
         tableView.backgroundColor = theme.backgroundColor
-        tableView.separatorStyle = theme.cellStyle.separatorStyle
-        tableView.separatorInset = theme.cellStyle.separatorInsets
-        tableView.separatorColor = theme.cellStyle.separatorColor
+        if self.customListItem == nil {
+            tableView.separatorStyle = theme.cellStyle.separatorStyle
+            tableView.separatorInset = theme.cellStyle.separatorInsets
+            tableView.separatorColor = theme.cellStyle.separatorColor
+        } else {
+            tableView.separatorStyle = .none
+            tableView.separatorInset = .zero
+            tableView.separatorColor = nil
+        }
         tableView.refreshControl?.tintColor = theme.loadingColor
         loadingIndicator.color = theme.loadingColor
         infoView.setTheme(theme)
-
+        
         tableView.appendAccessibilityIdentifier("InboxMessage")
         loadingIndicator.appendAccessibilityIdentifier("InboxMessage")
-
+        
         self.tableView.reloadData()
     }
     
-    /**
-     Clear the listeners
-     */
     deinit {
         Task { [self] in
             await self.authListener?.remove()
         }
     }
-    
 }

--- a/Sources/Courier_iOS/UI/Preferences/CourierPreferences.swift
+++ b/Sources/Courier_iOS/UI/Preferences/CourierPreferences.swift
@@ -11,6 +11,11 @@ import UIKit
 @available(iOSApplicationExtension, unavailable)
 open class CourierPreferences: UIView, UITableViewDelegate, UITableViewDataSource, UISheetPresentationControllerDelegate {
     
+    public typealias CustomListItemView = (_ view: CourierPreferences, _ topic: CourierUserPreferencesTopic, _ section: Int, _ index: Int) -> UIView
+    public typealias CustomLoadingStateView = () -> UIView
+    public typealias CustomEmptyStateView = (_ onRetry: @escaping () -> Void) -> UIView
+    public typealias CustomErrorStateView = (_ message: String, _ onRetry: @escaping () -> Void) -> UIView
+    
     // MARK: Theme
     
     public enum Mode {
@@ -26,6 +31,15 @@ open class CourierPreferences: UIView, UITableViewDelegate, UITableViewDataSourc
     // Sets the theme and propagates the change
     // Defaults to light mode, but will change when the theme is set
     private var theme: CourierPreferencesTheme = .defaultLight
+    
+    // MARK: Custom Views
+    
+    private static let customListItemId = "CustomPreferenceListItem"
+    private let customListItem: CustomListItemView?
+    private let customLoadingState: CustomLoadingStateView?
+    private let customEmptyState: CustomEmptyStateView?
+    private let customErrorState: CustomErrorStateView?
+    private var activeStateView: UIView? = nil
     
     // MARK: Data
     
@@ -55,6 +69,9 @@ open class CourierPreferences: UIView, UITableViewDelegate, UITableViewDataSourc
         tableView.backgroundColor = .systemBackground
         tableView.delegate = self
         tableView.dataSource = self
+        if customListItem != nil {
+            tableView.register(UITableViewCell.self, forCellReuseIdentifier: CourierPreferences.customListItemId)
+        }
         tableView.register(CourierPreferenceSectionHeaderView.self, forHeaderFooterViewReuseIdentifier: CourierPreferenceSectionHeaderView.id)
         tableView.register(CourierPreferenceTopicCell.self, forCellReuseIdentifier: CourierPreferenceTopicCell.id)
         tableView.refreshControl = refreshControl
@@ -85,6 +102,13 @@ open class CourierPreferences: UIView, UITableViewDelegate, UITableViewDataSourc
         return refreshControl
     }()
     
+    private lazy var stateContainer: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.isHidden = true
+        return view
+    }()
+    
     // MARK: Constraints
     
     private var infoViewY: NSLayoutConstraint?
@@ -96,23 +120,52 @@ open class CourierPreferences: UIView, UITableViewDelegate, UITableViewDataSourc
             
             switch (state) {
             case .loading:
-                self.loadingIndicator.startAnimating()
-                self.tableView.isHidden = true
-                self.infoView.isHidden = true
-            case .error:
-                self.loadingIndicator.stopAnimating()
-                self.tableView.isHidden = true
-                self.infoView.isHidden = false
-                self.infoView.updateView(state, actionTitle: "Retry", contentTitle: "No preferences found")
+                if let customLoadingState = self.customLoadingState {
+                    self.loadingIndicator.stopAnimating()
+                    self.tableView.isHidden = true
+                    self.infoView.isHidden = true
+                    self.showStateView(customLoadingState())
+                } else {
+                    self.hideStateView()
+                    self.loadingIndicator.startAnimating()
+                    self.tableView.isHidden = true
+                    self.infoView.isHidden = true
+                }
+            case .error(let message):
+                if let customErrorState = self.customErrorState {
+                    self.loadingIndicator.stopAnimating()
+                    self.tableView.isHidden = true
+                    self.infoView.isHidden = true
+                    self.showStateView(customErrorState(message, { [weak self] in
+                        self?.retry()
+                    }))
+                } else {
+                    self.hideStateView()
+                    self.loadingIndicator.stopAnimating()
+                    self.tableView.isHidden = true
+                    self.infoView.isHidden = false
+                    self.infoView.updateView(state, actionTitle: "Retry", contentTitle: "No preferences found")
+                }
             case .content:
+                self.hideStateView()
                 self.loadingIndicator.stopAnimating()
                 self.tableView.isHidden = false
                 self.infoView.isHidden = true
             case .empty:
-                self.loadingIndicator.stopAnimating()
-                self.tableView.isHidden = true
-                self.infoView.isHidden = false
-                self.infoView.updateView(state, actionTitle: "Retry", contentTitle: "No preferences found")
+                if let customEmptyState = self.customEmptyState {
+                    self.loadingIndicator.stopAnimating()
+                    self.tableView.isHidden = true
+                    self.infoView.isHidden = true
+                    self.showStateView(customEmptyState({ [weak self] in
+                        self?.retry()
+                    }))
+                } else {
+                    self.hideStateView()
+                    self.loadingIndicator.stopAnimating()
+                    self.tableView.isHidden = true
+                    self.infoView.isHidden = false
+                    self.infoView.updateView(state, actionTitle: "Retry", contentTitle: "No preferences found")
+                }
             }
             
             // Scroll to top if needed
@@ -131,12 +184,20 @@ open class CourierPreferences: UIView, UITableViewDelegate, UITableViewDataSourc
         mode: CourierPreferences.Mode = .channels(CourierUserPreferencesChannel.allCases),
         lightTheme: CourierPreferencesTheme = .defaultLight,
         darkTheme: CourierPreferencesTheme = .defaultDark,
+        customListItem: CustomListItemView? = nil,
+        customLoadingState: CustomLoadingStateView? = nil,
+        customEmptyState: CustomEmptyStateView? = nil,
+        customErrorState: CustomErrorStateView? = nil,
         didScrollPreferences: ((UIScrollView) -> Void)? = nil,
         onError: ((CourierError) -> String)? = nil
     ) {
         self.mode = mode
         self.lightTheme = lightTheme
         self.darkTheme = darkTheme
+        self.customListItem = customListItem
+        self.customLoadingState = customLoadingState
+        self.customEmptyState = customEmptyState
+        self.customErrorState = customErrorState
         self.didScrollPreferences = didScrollPreferences
         self.onError = onError
         super.init(frame: .zero)
@@ -149,6 +210,10 @@ open class CourierPreferences: UIView, UITableViewDelegate, UITableViewDataSourc
         self.mode = .channels(CourierUserPreferencesChannel.allCases)
         self.lightTheme = .defaultLight
         self.darkTheme = .defaultDark
+        self.customListItem = nil
+        self.customLoadingState = nil
+        self.customEmptyState = nil
+        self.customErrorState = nil
         self.onError = nil
         super.init(frame: frame)
         setup()
@@ -158,6 +223,10 @@ open class CourierPreferences: UIView, UITableViewDelegate, UITableViewDataSourc
         self.mode = .channels(CourierUserPreferencesChannel.allCases)
         self.lightTheme = .defaultLight
         self.darkTheme = .defaultDark
+        self.customListItem = nil
+        self.customLoadingState = nil
+        self.customEmptyState = nil
+        self.customErrorState = nil
         self.onError = nil
         super.init(coder: coder)
         setup()
@@ -185,6 +254,7 @@ open class CourierPreferences: UIView, UITableViewDelegate, UITableViewDataSourc
         addTableView()
         addLoadingIndicator()
         addInfoView()
+        addStateContainer()
         
         // Set state
         state = .loading
@@ -195,6 +265,11 @@ open class CourierPreferences: UIView, UITableViewDelegate, UITableViewDataSourc
         // Grab details
         refresh()
         
+    }
+    
+    private func retry() {
+        state = .loading
+        onRefresh()
     }
     
     func refresh() {
@@ -315,6 +390,50 @@ open class CourierPreferences: UIView, UITableViewDelegate, UITableViewDataSourc
         
     }
     
+    private func addStateContainer() {
+        addSubview(stateContainer)
+        
+        NSLayoutConstraint.activate([
+            stateContainer.topAnchor.constraint(equalTo: topAnchor),
+            stateContainer.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stateContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stateContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+    }
+    
+    private func showStateView(_ view: UIView) {
+        activeStateView?.removeFromSuperview()
+        activeStateView = view
+        view.translatesAutoresizingMaskIntoConstraints = false
+        stateContainer.isHidden = false
+        stateContainer.addSubview(view)
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: stateContainer.topAnchor),
+            view.bottomAnchor.constraint(equalTo: stateContainer.bottomAnchor),
+            view.leadingAnchor.constraint(equalTo: stateContainer.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: stateContainer.trailingAnchor),
+        ])
+    }
+    
+    private func hideStateView() {
+        activeStateView?.removeFromSuperview()
+        activeStateView = nil
+        stateContainer.isHidden = true
+    }
+    
+    private func renderCustomView(in cell: UITableViewCell, view: UIView) {
+        cell.selectionStyle = .none
+        cell.contentView.subviews.forEach { $0.removeFromSuperview() }
+        view.translatesAutoresizingMaskIntoConstraints = false
+        cell.contentView.addSubview(view)
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: cell.contentView.topAnchor),
+            view.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor),
+            view.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor),
+        ])
+    }
+    
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         
@@ -337,9 +456,15 @@ open class CourierPreferences: UIView, UITableViewDelegate, UITableViewDataSourc
         tableView.backgroundColor = self.theme.backgroundColor
         
         // Table theme
-        tableView.separatorStyle = self.theme.topicCellStyles.separatorStyle
-        tableView.separatorInset = self.theme.topicCellStyles.separatorInsets
-        tableView.separatorColor = self.theme.topicCellStyles.separatorColor
+        if self.customListItem == nil {
+            tableView.separatorStyle = self.theme.topicCellStyles.separatorStyle
+            tableView.separatorInset = self.theme.topicCellStyles.separatorInsets
+            tableView.separatorColor = self.theme.topicCellStyles.separatorColor
+        } else {
+            tableView.separatorStyle = .none
+            tableView.separatorInset = .zero
+            tableView.separatorColor = nil
+        }
         
         // Loading indicators
         tableView.refreshControl?.tintColor = self.theme.loadingColor
@@ -387,10 +512,15 @@ open class CourierPreferences: UIView, UITableViewDelegate, UITableViewDataSourc
     }
     
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let topic = preferences[indexPath.section].topics[indexPath.row]
+        
+        if let customListItem = self.customListItem {
+            let cell = tableView.dequeueReusableCell(withIdentifier: CourierPreferences.customListItemId, for: indexPath)
+            renderCustomView(in: cell, view: customListItem(self, topic, indexPath.section, indexPath.row))
+            return cell
+        }
         
         let cell = tableView.dequeueReusableCell(withIdentifier: CourierPreferenceTopicCell.id, for: indexPath) as! CourierPreferenceTopicCell
-        
-        let topic = preferences[indexPath.section].topics[indexPath.row]
         cell.configureCell(
             topic: topic,
             mode: self.mode,
@@ -427,7 +557,7 @@ open class CourierPreferences: UIView, UITableViewDelegate, UITableViewDataSourc
         return Theme.Preferences.topicCellHeight
     }
     
-    private func showSheet(topic: CourierUserPreferencesTopic) {
+    public func showSheet(topic: CourierUserPreferencesTopic) {
         
         guard let parentViewController = parentViewController else {
             fatalError("CourierPreferences must be added to a view hierarchy with a ViewController.")

--- a/Sources/Courier_iOS/UI/Preferences/CourierPreferencesView.swift
+++ b/Sources/Courier_iOS/UI/Preferences/CourierPreferencesView.swift
@@ -11,28 +11,120 @@ import SwiftUI
 @available(iOSApplicationExtension, unavailable)
 public struct CourierPreferencesView: UIViewRepresentable {
     
+    public typealias UIViewType = CourierPreferences
+    
     private let preferences: CourierPreferences
     
     public init(
         mode: CourierPreferences.Mode = .channels(CourierUserPreferencesChannel.allCases),
         lightTheme: CourierPreferencesTheme = .defaultLight,
         darkTheme: CourierPreferencesTheme = .defaultDark,
+        customListItem: CourierPreferences.CustomListItemView? = nil,
+        customLoadingState: CourierPreferences.CustomLoadingStateView? = nil,
+        customEmptyState: CourierPreferences.CustomEmptyStateView? = nil,
+        customErrorState: CourierPreferences.CustomErrorStateView? = nil,
         onError: ((CourierError) -> String)? = nil
     ) {
         self.preferences = CourierPreferences(
             mode: mode,
             lightTheme: lightTheme,
             darkTheme: darkTheme,
+            customListItem: customListItem,
+            customLoadingState: customLoadingState,
+            customEmptyState: customEmptyState,
+            customErrorState: customErrorState,
             onError: onError
         )
     }
     
-    public func makeUIView(context: Context) -> some UIView {
+    public func makeUIView(context: Context) -> CourierPreferences {
         return preferences
     }
     
     public func updateUIView(_ uiView: UIViewType, context: Context) {
         // Empty
     }
+}
+
+@available(iOS 15.0, *)
+@available(iOSApplicationExtension, unavailable)
+public extension CourierPreferencesView {
     
+    struct SwiftUICustomViews {
+        public let listItem: ((_ view: CourierPreferences, _ topic: CourierUserPreferencesTopic, _ section: Int, _ index: Int) -> AnyView)?
+        public let loadingState: (() -> AnyView)?
+        public let emptyState: ((_ onRetry: @escaping () -> Void) -> AnyView)?
+        public let errorState: ((_ message: String, _ onRetry: @escaping () -> Void) -> AnyView)?
+        
+        public init(
+            listItem: ((_ view: CourierPreferences, _ topic: CourierUserPreferencesTopic, _ section: Int, _ index: Int) -> AnyView)? = nil,
+            loadingState: (() -> AnyView)? = nil,
+            emptyState: ((_ onRetry: @escaping () -> Void) -> AnyView)? = nil,
+            errorState: ((_ message: String, _ onRetry: @escaping () -> Void) -> AnyView)? = nil
+        ) {
+            self.listItem = listItem
+            self.loadingState = loadingState
+            self.emptyState = emptyState
+            self.errorState = errorState
+        }
+    }
+    
+    private static func host<Content: View>(_ view: Content) -> UIView {
+        let host = UIHostingController(rootView: view)
+        host.view.backgroundColor = .clear
+        return host.view
+    }
+    
+    init(
+        mode: CourierPreferences.Mode = .channels(CourierUserPreferencesChannel.allCases),
+        lightTheme: CourierPreferencesTheme = .defaultLight,
+        darkTheme: CourierPreferencesTheme = .defaultDark,
+        swiftUICustomViews: SwiftUICustomViews,
+        onError: ((CourierError) -> String)? = nil
+    ) {
+        self.init(
+            mode: mode,
+            lightTheme: lightTheme,
+            darkTheme: darkTheme,
+            customListItem: swiftUICustomViews.listItem.map { render in
+                { view, topic, section, index in
+                    CourierPreferencesView.host(render(view, topic, section, index))
+                }
+            },
+            customLoadingState: swiftUICustomViews.loadingState.map { render in
+                {
+                    CourierPreferencesView.host(render())
+                }
+            },
+            customEmptyState: swiftUICustomViews.emptyState.map { render in
+                { onRetry in
+                    CourierPreferencesView.host(render(onRetry))
+                }
+            },
+            customErrorState: swiftUICustomViews.errorState.map { render in
+                { message, onRetry in
+                    CourierPreferencesView.host(render(message, onRetry))
+                }
+            },
+            onError: onError
+        )
+    }
+    
+    init<CustomListItem: View>(
+        mode: CourierPreferences.Mode = .channels(CourierUserPreferencesChannel.allCases),
+        lightTheme: CourierPreferencesTheme = .defaultLight,
+        darkTheme: CourierPreferencesTheme = .defaultDark,
+        onError: ((CourierError) -> String)? = nil,
+        @ViewBuilder customListItem: @escaping (_ view: CourierPreferences, _ topic: CourierUserPreferencesTopic, _ section: Int, _ index: Int) -> CustomListItem
+    ) {
+        self.init(
+            mode: mode,
+            lightTheme: lightTheme,
+            darkTheme: darkTheme,
+            customListItem: { view, topic, section, index in
+                CourierPreferencesView.host(customListItem(view, topic, section, index))
+            },
+            onError: onError
+        )
+    }
 }

--- a/Sources/Courier_iOS/UI/TabView.swift
+++ b/Sources/Courier_iOS/UI/TabView.swift
@@ -9,6 +9,7 @@ import UIKit
 
 @available(iOSApplicationExtension, unavailable)
 internal struct Page {
+    let feed: InboxMessageFeed
     let title: String
     let page: InboxMessageListView
 }
@@ -26,6 +27,7 @@ internal class TabView: UIView, UIScrollViewDelegate {
     let scrollView: UIScrollView
     let onTabSelected: (Int) -> Void
     let onTabReselected: (Int) -> Void
+    let customTabItem: ((InboxMessageFeed, String, Bool, Int?) -> UIView)?
     private var theme: CourierInboxTheme? = nil
     private(set) var selectedIndex: Int = 0
     
@@ -46,9 +48,16 @@ internal class TabView: UIView, UIScrollViewDelegate {
     
     private(set) var tabs: [Tab] = []
     
-    public init(pages: [Page], scrollView: UIScrollView, onTabSelected: @escaping (Int) -> Void, onTabReselected: @escaping (Int) -> Void) {
+    public init(
+        pages: [Page],
+        scrollView: UIScrollView,
+        customTabItem: ((InboxMessageFeed, String, Bool, Int?) -> UIView)? = nil,
+        onTabSelected: @escaping (Int) -> Void,
+        onTabReselected: @escaping (Int) -> Void
+    ) {
         self.pages = pages
         self.scrollView = scrollView
+        self.customTabItem = customTabItem
         self.onTabSelected = onTabSelected
         self.onTabReselected = onTabReselected
         super.init(frame: .zero)
@@ -58,6 +67,7 @@ internal class TabView: UIView, UIScrollViewDelegate {
     override init(frame: CGRect) {
         self.pages = []
         self.scrollView = UIScrollView()
+        self.customTabItem = nil
         self.onTabSelected = { _ in }
         self.onTabReselected = { _ in }
         super.init(frame: frame)
@@ -67,6 +77,7 @@ internal class TabView: UIView, UIScrollViewDelegate {
     public required init?(coder: NSCoder) {
         self.pages = []
         self.scrollView = UIScrollView()
+        self.customTabItem = nil
         self.onTabSelected = { _ in }
         self.onTabReselected = { _ in }
         super.init(coder: coder)
@@ -88,7 +99,11 @@ internal class TabView: UIView, UIScrollViewDelegate {
         
         // Initialize tabs and add them to the stack view
         for (pageIndex, page) in pages.enumerated() {
-            let tab = Tab(title: page.title, onTapped: { [weak self] in
+            let tab = Tab(
+                title: page.title,
+                feed: page.feed,
+                customTabItem: customTabItem,
+                onTapped: { [weak self] in
                 guard let self = self else { return }
                 
                 if self.selectedIndex == pageIndex {
@@ -181,8 +196,11 @@ internal class TabView: UIView, UIScrollViewDelegate {
 internal class Tab: UIButton {
     
     let title: String
+    let feed: InboxMessageFeed
+    let customTabItem: ((InboxMessageFeed, String, Bool, Int?) -> UIView)?
     let onTapped: () -> Void
     private var theme: CourierInboxTheme? = nil
+    private var customContentView: UIView? = nil
     
     var isTabSelected = false {
         didSet {
@@ -223,20 +241,39 @@ internal class Tab: UIButton {
     }()
 
     private func refresh() {
-        
-        tabNameLabel.text = title
-        
-        let style = isTabSelected ? theme?.tabStyle.selected.font : theme?.tabStyle.unselected.font
-        tabNameLabel.textColor = style?.color
-        tabNameLabel.font = style?.font
-        
-        if let theme = self.theme {
-            let badge = getBadgeValue(value: self.badge ?? 0)
-            badgeLabel.refresh(
-                theme: theme,
-                badge: badge,
-                isSelected: isTabSelected
-            )
+        if let customTabItem = customTabItem {
+            stackView.isHidden = true
+            customContentView?.removeFromSuperview()
+            let customView = customTabItem(feed, title, isTabSelected, badge)
+            customView.translatesAutoresizingMaskIntoConstraints = false
+            customView.isUserInteractionEnabled = false
+            addSubview(customView)
+            NSLayoutConstraint.activate([
+                customView.topAnchor.constraint(equalTo: topAnchor),
+                customView.bottomAnchor.constraint(equalTo: bottomAnchor),
+                customView.leadingAnchor.constraint(equalTo: leadingAnchor),
+                customView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            ])
+            customContentView = customView
+        } else {
+            stackView.isHidden = false
+            customContentView?.removeFromSuperview()
+            customContentView = nil
+            
+            tabNameLabel.text = title
+            
+            let style = isTabSelected ? theme?.tabStyle.selected.font : theme?.tabStyle.unselected.font
+            tabNameLabel.textColor = style?.color
+            tabNameLabel.font = style?.font
+            
+            if let theme = self.theme {
+                let badge = getBadgeValue(value: self.badge ?? 0)
+                badgeLabel.refresh(
+                    theme: theme,
+                    badge: badge,
+                    isSelected: isTabSelected
+                )
+            }
         }
         
         setNeedsLayout()
@@ -262,8 +299,15 @@ internal class Tab: UIButton {
         refresh()
     }
     
-    public init(title: String, onTapped: @escaping () -> Void) {
+    public init(
+        title: String,
+        feed: InboxMessageFeed,
+        customTabItem: ((InboxMessageFeed, String, Bool, Int?) -> UIView)? = nil,
+        onTapped: @escaping () -> Void
+    ) {
         self.title = title
+        self.feed = feed
+        self.customTabItem = customTabItem
         self.onTapped = onTapped
         super.init(frame: .zero)
         setup()
@@ -271,6 +315,8 @@ internal class Tab: UIButton {
 
     override init(frame: CGRect) {
         self.title = ""
+        self.feed = .feed
+        self.customTabItem = nil
         self.onTapped = {}
         super.init(frame: frame)
         setup()
@@ -278,6 +324,8 @@ internal class Tab: UIButton {
     
     public required init?(coder: NSCoder) {
         self.title = ""
+        self.feed = .feed
+        self.customTabItem = nil
         self.onTapped = {}
         super.init(coder: coder)
         setup()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add UIKit customization hooks for inbox tabs, list items, empty/loading/error states, and optional pagination item rendering
- add UIKit customization hooks for preferences topic rows plus empty/loading/error states, and expose `showSheet(topic:)` for custom row interactions
- extend SwiftUI wrappers to pass through new UIKit hooks and add SwiftUI-focused customization containers for rendering custom content via hosted views

## Validation
- pending build/test validation in follow-up commit
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9dbda30b-69ff-4801-8f45-e8a405989453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9dbda30b-69ff-4801-8f45-e8a405989453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

