### PR TITLE
chore: update homepage to courier.com and bump to 5.8.5

### DIFF
--- a/Courier_iOS.podspec
+++ b/Courier_iOS.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
 
     s.name = 'Courier_iOS'
-    s.version = '5.8.4'
+    s.version = '5.8.5'
     s.summary = 'Courier makes it easy to add notifications to your app'
 
-    s.homepage = 'https://github.com/trycourier/courier-ios'
+    s.homepage = 'https://courier.com'
     s.license = { :type => 'MIT', :text => <<-LICENSE
                            Copyright 2023 TryCourier
 

--- a/Courier_iOS.podspec
+++ b/Courier_iOS.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
 
     s.homepage = 'https://courier.com'
     s.license = { :type => 'MIT', :text => <<-LICENSE
-                           Copyright 2023 TryCourier
+                           Copyright 2026 TryCourier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/Sources/Courier_iOS/Courier_iOS.swift
+++ b/Sources/Courier_iOS/Courier_iOS.swift
@@ -26,7 +26,7 @@ import UIKit
     
     // MARK: Versioning
     
-    internal static let version = "5.8.4"
+    internal static let version = "5.8.5"
     @objc public static var agent = CourierAgent.nativeIOS(version)
     
     // MARK: Singleton


### PR DESCRIPTION
## Summary
- Updates the `homepage` field in `Courier_iOS.podspec` from the GitHub repo URL to `https://courier.com` so it displays correctly on CocoaPods
- Bumps version from 5.8.4 → 5.8.5 (podspec + source constant)

## Test plan
- [ ] Verify `homepage` field shows correctly on CocoaPods after publish

Made with [Cursor](https://cursor.com)