### PR TITLE
feat(inbox): migrate the inbox socket from legacy to iwpv=v2

### DIFF
--- a/Sources/Courier_iOS/Models/InboxMessage.swift
+++ b/Sources/Courier_iOS/Models/InboxMessage.swift
@@ -93,14 +93,20 @@ public class InboxMessage: Codable {
         opened = nil
     }
     
+    /**
+     Tracking id for a click on this message.
+
+     Reads the root-level `trackingIds` only. Both the GraphQL read and the `iwpv=v2` socket
+     publish it there, so the two shapes finally agree.
+
+     The nested `data["trackingIds"]` branch that used to be checked first is gone. It existed
+     because the socket, on the `legacy` protocol, nested tracking ids under `data` while
+     GraphQL returned them at the root — so this property had to look in both places and
+     guess. Removing it is only safe because the socket now speaks v2; on `legacy` the nested
+     copy was the *only* one present.
+     */
     public var clickTrackingId: String? {
-        get {
-            if let trackingIdsDict = data?["trackingIds"] as? [String: Any],
-               let clickTrackingId = trackingIdsDict["clickTrackingId"] as? String {
-                return clickTrackingId
-            }
-            return trackingIds?.clickTrackingId
-        }
+        return trackingIds?.clickTrackingId
     }
     
     public var createdAt: Date {

--- a/Sources/Courier_iOS/Socket/CourierSocket.swift
+++ b/Sources/Courier_iOS/Socket/CourierSocket.swift
@@ -95,12 +95,22 @@ public class CourierSocket: NSObject, URLSessionWebSocketDelegate {
         try await task?.send(message)
     }
     
-    // Pings keep alive. Will ping every 5 minutes by default
+    /**
+     Pings keep alive. Will ping every 5 minutes by default.
+
+     Sends the inbox wire protocol `ping`, not the old `keepAlive` action. `keepAlive` is not a
+     valid IWP action and carries no `tid`, so under `iwpv=v2` it would fail envelope
+     validation and come back as an error frame every interval — the server accepts only
+     subscribe / unsubscribe / ping / pong / stats / get-config, each requiring a `tid`.
+
+     The server also drives its own heartbeat and drops a connection that fails to pong, so
+     this timer is belt-and-braces rather than the sole liveness mechanism.
+     */
     public func keepAlive(interval: TimeInterval = 300) async {
-        
+
         // Ensure any existing timer is invalidated
         pingTimer?.invalidate()
-        
+
         // Create and schedule a new timer
         await MainActor.run { [weak self] in
             guard let self = self else { return }
@@ -108,7 +118,8 @@ public class CourierSocket: NSObject, URLSessionWebSocketDelegate {
                 Task {
                     do {
                         try await self.send([
-                            "action": "keepAlive"
+                            "tid": UUID().uuidString,
+                            "action": "ping"
                         ])
                     } catch {
                         await Courier.shared.client?.log(error.localizedDescription)
@@ -118,7 +129,7 @@ public class CourierSocket: NSObject, URLSessionWebSocketDelegate {
             // Ensure the timer runs in the common run loop mode
             RunLoop.main.add(self.pingTimer!, forMode: .common)
         }
-        
+
     }
     
     func receiveData() {

--- a/Sources/Courier_iOS/Socket/InboxSocket.swift
+++ b/Sources/Courier_iOS/Socket/InboxSocket.swift
@@ -56,25 +56,66 @@ internal actor InboxSocketState {
 // MARK: Inbox Socket
 
 public class InboxSocket: CourierSocket {
-    
+
     private let options: CourierClient.Options
     private let state = InboxSocketState()
-    
+
+    /**
+     Inbox wire protocol version, negotiated per connection via the `iwpv` query parameter.
+
+     `v2` publishes the canonical message — the same object the GraphQL read returns, with
+     `trackingIds` at the root and no nested `data.trackingIds` duplicate.
+
+     Previously this SDK sent no `iwpv` at all, which the server treats as `legacy`: a
+     different envelope (no `tid`, `keepAlive` instead of ping/pong) and a frame whose
+     message fields sit at the root. That is why `clickTrackingId` had to read
+     `data["trackingIds"]` first — on `legacy` the nested copy is the only one present.
+
+     The server downgrades an unrecognized version to `legacy` rather than rejecting the
+     connection, so this must not be raised ahead of server support: a client asking for a
+     version the server does not know gets the legacy shape and no error. v2 message frames
+     carry `iwpv` so a downgrade is detectable rather than silent.
+     */
+    internal static let protocolVersion = "v2"
+
     enum PayloadType: String, Codable {
         case event = "event"
         case message = "message"
     }
-    
+
     struct SocketPayload: Codable {
         let type: PayloadType
     }
-    
+
     public struct MessageEvent: Codable {
         let event: InboxEventType
         let messageId: String?
         let type: String
     }
-    
+
+    /**
+     A v2 frame. Messages arrive as `{"event":"message","iwpv":"v2","data":{…}}`; anything
+     else is a message event carrying its own `event` name at the root.
+     */
+    internal struct MessageFrame: Decodable {
+        let event: String
+        let iwpv: String?
+        let data: InboxMessage
+    }
+
+    /**
+     Server control frames: `{"tid":…,"response":"ack"|"pong"|"config"}` and
+     `{"iwpv":…,"tid":…,"action":"ping"}`.
+
+     Responding to `ping` is not optional — the server terminates a connection that fails to
+     pong within its timeout, so a client that ignores pings is dropped mid-session.
+     */
+    internal struct ControlFrame: Decodable {
+        let tid: String?
+        let action: String?
+        let response: String?
+    }
+
     internal var receivedMessage: ((InboxMessage) -> Void)?
     internal var receivedMessageEvent: ((MessageEvent) -> Void)?
     
@@ -97,67 +138,119 @@ public class InboxSocket: CourierSocket {
         try await super.connect()
     }
     
+    /**
+     Subscribe using the IWP envelope: `tid` and `action` at the root, options under `data`.
+
+     The `version` parameter is retained for source compatibility but is no longer sent — the
+     server hardcodes `clientVersion` for every IWP subscription, so passing it implied a
+     negotiation that does not happen.
+     */
     public func sendSubscribe(version: Int = 5) async throws {
-        
-        var data: [String: Any] = [
-            "action": "subscribe",
-            "data": [
-                "userAgent": Courier.agent.value,
-                "channel": options.userId,
-                "event": "*",
-                "version": version
-            ]
+
+        var subscription: [String: Any] = [
+            "userAgent": Courier.agent.value,
+            "event": "*"
         ]
-        
-        if var dict = data["data"] as? [String: Any] {
-            
-            if let clientKey = self.options.clientKey {
-                dict["clientKey"] = clientKey
-            }
-            
-            if let connectionId = self.options.connectionId {
-                dict["clientSourceId"] = connectionId
-            }
-            
-            if let tenantId = self.options.tenantId {
-                dict["accountId"] = tenantId
-            }
-            
-            data["data"] = dict
-            
+
+        if let tenantId = self.options.tenantId {
+            subscription["accountId"] = tenantId
         }
-        
-        try await send(data)
-        
+
+        try await send([
+            "tid": UUID().uuidString,
+            "action": "subscribe",
+            "data": subscription
+        ])
+
     }
     
-    private func convertToType(from data: String) {
-        do {
-            let decoder = JSONDecoder()
-            let json = data.data(using: .utf8) ?? Data()
-            let payload = try decoder.decode(SocketPayload.self, from: json)
+    /**
+     Route an incoming v2 frame.
 
-            switch payload.type {
-            case .event:
-                let event = try decoder.decode(MessageEvent.self, from: json)
-                Task { await state.callReceivedMessageEvent(event) } // Read safely via actor
-            case .message:
-                let message = try decoder.decode(InboxMessage.self, from: json)
-                Task { await state.callReceivedMessage(message) } // Read safely via actor
+     Three kinds arrive on one socket, distinguished without a `type` field (which v2 does not
+     send):
+
+     - a control frame carrying `action` or `response` — ack, config, or a `ping` that must be
+       answered
+     - `{"event":"message","data":{…}}` — a new message, canonical shape
+     - anything else with an `event` — a message event (read, archived, …)
+
+     Ordering matters: control frames are checked first, because a `ping` has no `event` and
+     would otherwise fall through to a failed message decode and surface as a spurious error.
+     */
+    private func convertToType(from data: String) {
+        let decoder = JSONDecoder()
+        let json = data.data(using: .utf8) ?? Data()
+
+        // Control frames first — see note above.
+        if let control = try? decoder.decode(ControlFrame.self, from: json) {
+            if control.action == "ping" {
+                // Mandatory: the server terminates a connection that does not pong in time.
+                Task { await self.sendPong(tid: control.tid) }
+                return
             }
+
+            // ack / pong / config carry no payload this SDK acts on, but they are not errors.
+            if control.response != nil {
+                return
+            }
+        }
+
+        do {
+            if let frame = try? decoder.decode(MessageFrame.self, from: json), frame.event == "message" {
+                if let iwpv = frame.iwpv, iwpv != InboxSocket.protocolVersion {
+                    // A downgrade would otherwise be invisible until tracking silently stopped.
+                    options.error("Inbox socket negotiated \(iwpv) but this client expects \(InboxSocket.protocolVersion). Tracking ids may be missing.")
+                }
+                Task { await state.callReceivedMessage(frame.data) } // Read safely via actor
+                return
+            }
+
+            let event = try decoder.decode(MessageEvent.self, from: json)
+            Task { await state.callReceivedMessageEvent(event) } // Read safely via actor
         } catch {
             options.error(error.localizedDescription)
             self.onError?(error)
         }
     }
-    
-    private static func buildUrl(options: CourierClient.Options) -> String {
+
+    /**
+     Answer a server heartbeat, echoing its `tid` — the server matches the pong against the
+     ping it is waiting on and ignores a mismatched one.
+     */
+    private func sendPong(tid: String?) async {
+        do {
+            try await send([
+                "tid": tid ?? UUID().uuidString,
+                "action": "pong"
+            ])
+        } catch {
+            options.error("Failed to answer inbox socket heartbeat: \(error.localizedDescription)")
+        }
+    }
+
+    /**
+     `cid` and `iwpv` are both required by the IWP handler — it rejects a connection missing
+     either, so they are appended for the client-key path as well as the JWT path.
+     */
+    internal static func buildUrl(options: CourierClient.Options) -> String {
         var url = options.apiUrls.inboxWebSocket
         if let jwt = options.jwt {
             url += "/?auth=\(jwt)"
         } else if let clientKey = options.clientKey {
             url += "/?clientKey=\(clientKey)"
+        } else {
+            url += "/?"
         }
+
+        // The server requires a client id; fall back to a generated one so a caller that never
+        // set connectionId still gets a valid IWP connection rather than a rejected one.
+        let clientId = options.connectionId ?? UUID().uuidString
+
+        url += "&cid=\(clientId)"
+        url += "&iwpv=\(InboxSocket.protocolVersion)"
+        url += "&userId=\(options.userId)"
+
         return url
     }
     

--- a/Tests/CourierTests/Unit/InboxSocketProtocolUnitTests.swift
+++ b/Tests/CourierTests/Unit/InboxSocketProtocolUnitTests.swift
@@ -1,0 +1,182 @@
+//
+//  InboxSocketProtocolUnitTests.swift
+//  Courier_iOS
+//
+//  Inbox wire protocol v2 (iwpv=v2).
+//
+//  These cover the two things that make v2 work and are otherwise invisible when they
+//  break: the connection URL must carry `cid` and `iwpv` (the server rejects an IWP
+//  connection missing either, and silently downgrades an unknown version to `legacy`),
+//  and `clickTrackingId` must read the root-level `trackingIds` that v2 publishes.
+//
+
+import Foundation
+import XCTest
+@testable import Courier_iOS
+
+class InboxSocketProtocolUnitTests: XCTestCase {
+
+    private func options(
+        jwt: String? = "test-jwt",
+        clientKey: String? = nil,
+        connectionId: String? = "conn-123",
+        tenantId: String? = nil
+    ) -> CourierClient.Options {
+        return CourierClient.Options(
+            jwt: jwt,
+            clientKey: clientKey,
+            userId: "user-1",
+            connectionId: connectionId,
+            tenantId: tenantId,
+            showLogs: false,
+            apiUrls: CourierClient.ApiUrls()
+        )
+    }
+
+    /// Parses the connection URL rather than opening a socket, so these stay pure unit tests.
+    private func queryItems(for options: CourierClient.Options) -> [String: String] {
+        guard let components = URLComponents(string: InboxSocket.buildUrl(options: options)) else {
+            return [:]
+        }
+        var items: [String: String] = [:]
+        for item in components.queryItems ?? [] {
+            items[item.name] = item.value
+        }
+        return items
+    }
+
+    // MARK: Connection URL
+
+    func testUrlDeclaresProtocolVersionV2() {
+        let items = queryItems(for: options())
+        XCTAssertEqual(items["iwpv"], "v2")
+        XCTAssertEqual(InboxSocket.protocolVersion, "v2")
+    }
+
+    func testUrlCarriesClientIdWhichTheServerRequires() {
+        let items = queryItems(for: options(connectionId: "conn-123"))
+        XCTAssertEqual(items["cid"], "conn-123")
+    }
+
+    // Without a cid the IWP handler closes the connection, so a caller that never set
+    // connectionId must still get a usable socket rather than a rejected one.
+    func testUrlGeneratesAClientIdWhenNoneWasProvided() {
+        let items = queryItems(for: options(connectionId: nil))
+        XCTAssertNotNil(items["cid"])
+        XCTAssertFalse(items["cid"]?.isEmpty ?? true)
+    }
+
+    func testUrlKeepsJwtAuth() {
+        let items = queryItems(for: options(jwt: "test-jwt"))
+        XCTAssertEqual(items["auth"], "test-jwt")
+    }
+
+    // The client-key path previously returned before any IWP params were appended.
+    func testUrlCarriesProtocolParamsOnTheClientKeyPath() {
+        let items = queryItems(for: options(jwt: nil, clientKey: "ck-1"))
+        XCTAssertEqual(items["clientKey"], "ck-1")
+        XCTAssertEqual(items["iwpv"], "v2")
+        XCTAssertNotNil(items["cid"])
+    }
+
+    // MARK: Tracking ids
+
+    /**
+     v2 publishes `trackingIds` at the root. The nested `data["trackingIds"]` branch that
+     used to be consulted first is gone — it only existed because the `legacy` socket nested
+     them while GraphQL returned them at the root.
+     */
+    func testClickTrackingIdReadsTheRootLevelValue() throws {
+        let json = """
+        {
+          "messageId": "msg-1",
+          "title": "Welcome",
+          "trackingIds": { "clickTrackingId": "click-root" },
+          "data": { "orderId": "ord_1" }
+        }
+        """
+        let message = try JSONDecoder().decode(InboxMessage.self, from: Data(json.utf8))
+
+        XCTAssertEqual(message.clickTrackingId, "click-root")
+    }
+
+    func testClickTrackingIdIsNilWhenAbsent() throws {
+        let json = """
+        { "messageId": "msg-1", "title": "Welcome" }
+        """
+        let message = try JSONDecoder().decode(InboxMessage.self, from: Data(json.utf8))
+
+        XCTAssertNil(message.clickTrackingId)
+    }
+
+    /**
+     A nested-only copy is what a `legacy` frame looks like. v2 never sends it, and reading it
+     would mask a silent downgrade — so this asserts the fallback really is gone.
+     */
+    func testClickTrackingIdIgnoresANestedOnlyCopy() throws {
+        let json = """
+        {
+          "messageId": "msg-1",
+          "data": { "trackingIds": { "clickTrackingId": "click-nested" } }
+        }
+        """
+        let message = try JSONDecoder().decode(InboxMessage.self, from: Data(json.utf8))
+
+        XCTAssertNil(message.clickTrackingId)
+    }
+
+    // MARK: Frame decoding
+
+    func testMessageFrameDecodesTheCanonicalMessageFromData() throws {
+        let json = """
+        {
+          "event": "message",
+          "iwpv": "v2",
+          "data": {
+            "messageId": "msg-1",
+            "title": "Welcome",
+            "preview": "Preview",
+            "created": "2026-08-05T12:00:00.000Z",
+            "trackingIds": { "clickTrackingId": "click-1", "readTrackingId": "read-1" },
+            "data": { "orderId": "ord_1" }
+          }
+        }
+        """
+        let frame = try JSONDecoder().decode(InboxSocket.MessageFrame.self, from: Data(json.utf8))
+
+        XCTAssertEqual(frame.event, "message")
+        XCTAssertEqual(frame.iwpv, "v2")
+        XCTAssertEqual(frame.data.messageId, "msg-1")
+        XCTAssertEqual(frame.data.title, "Welcome")
+        XCTAssertEqual(frame.data.clickTrackingId, "click-1")
+        XCTAssertEqual(frame.data.trackingIds?.readTrackingId, "read-1")
+        // `data` keeps only non-promoted keys under v2.
+        XCTAssertEqual(frame.data.data?["orderId"] as? String, "ord_1")
+    }
+
+    /**
+     A heartbeat must be recognized as a control frame. It has no `event`, so if it fell
+     through to the message decode it would surface as a spurious error every ping interval —
+     and an unanswered ping gets the connection terminated by the server.
+     */
+    func testPingDecodesAsAControlFrame() throws {
+        let json = """
+        { "iwpv": "v2", "tid": "tid-1", "action": "ping" }
+        """
+        let control = try JSONDecoder().decode(InboxSocket.ControlFrame.self, from: Data(json.utf8))
+
+        XCTAssertEqual(control.action, "ping")
+        XCTAssertEqual(control.tid, "tid-1")
+        XCTAssertNil(control.response)
+    }
+
+    func testAckDecodesAsAControlFrame() throws {
+        let json = """
+        { "tid": "tid-1", "response": "ack" }
+        """
+        let control = try JSONDecoder().decode(InboxSocket.ControlFrame.self, from: Data(json.utf8))
+
+        XCTAssertEqual(control.response, "ack")
+        XCTAssertNil(control.action)
+    }
+}


### PR DESCRIPTION
Ticket: [C-19800](https://linear.app/trycourier/issue/C-19800/inbox-socket-add-iwpvv2-with-a-canonical-message-payload-and-migrate)

> [!IMPORTANT]
> **Do not merge before trycourier/services#1527 is deployed.** The server downgrades an unrecognized `iwpv` to the *legacy* protocol rather than rejecting the connection, so shipping this first would silently move clients onto the legacy shape with no error.

## This SDK was on `legacy`, not v1

It sent **no `iwpv` query parameter at all**, which the server treats as the `legacy` protocol — a different envelope and a different frame shape from the one GraphQL agrees with.

That's the root cause of the `clickTrackingId` guesswork. On `legacy` the socket nests tracking ids under `data` while the GraphQL read returns them at the root, so the property had to check `data["trackingIds"]` first and fall back to the root. The `// TODO` to clean this up has been standing for a while; this is what makes it safe.

## Legacy → v2 is a protocol change, not a version bump

All four pieces have to move together:

| | before (`legacy`) | after (`iwpv=v2`) |
| --- | --- | --- |
| **URL** | `?auth=…` only | `+ cid` and `+ iwpv` — the IWP handler **rejects** a connection missing either |
| **Subscribe** | `{action, data}`, no `tid` | IWP envelope: `tid` + `action` at root |
| **Heartbeat** | `{action:"keepAlive"}` | IWP `ping`, and **answers** server pings |
| **Frame** | message fields at the frame **root** | `{"event":"message","iwpv":"v2","data":{…}}` |

Details worth flagging in review:

- **`cid` on the client-key path.** `buildUrl` previously returned before any params were appended on that branch. A client id is also generated when the caller never set `connectionId`, so that path yields a valid connection rather than a rejected one.
- **Answering pings is mandatory.** The server terminates a connection that fails to pong within its timeout, echoing the `tid` it's waiting on. A v2 client that ignores pings gets dropped mid-session.
- **`keepAlive` had to go.** It isn't a valid IWP action *and* carries no `tid`, so under v2 it would fail envelope validation and return an error frame every interval. It's now an IWP `ping`.
- **Control frames are parsed first.** A `ping` has no `event`, so if it fell through to the message decode it would surface as a spurious error every heartbeat.
- **`version:` on `sendSubscribe` is retained but no longer sent** — the server hardcodes `clientVersion` for every IWP subscription, so passing it implied a negotiation that doesn't happen. Kept in the signature for source compatibility.

## The fallback removal is safe *because of* the protocol move

`clickTrackingId` now reads the root-level value only. Dropping the nested branch on its own would have **broken click tracking outright**, since on `legacy` the nested copy is the only one present. The two changes are not separable.

A mismatched `iwpv` on an incoming frame is logged — without it, a silent downgrade stays invisible until tracking quietly stops.

## Tests

11 new unit tests, `xcodebuild test` against an iOS 26 simulator, all passing:

- protocol version and `cid` present on **both** auth paths; generated client id when `connectionId` is unset; JWT auth preserved
- root-level tracking id read; nested-only copy correctly **ignored** (asserts the fallback is really gone); nil when absent
- canonical frame decodes the message from `data`, incl. `trackingIds` and the promoted-key-free `data`
- `ping` and `ack` decode as control frames

Note the test target needs the gitignored `Tests/CourierTests/Env.swift` to compile at all — pre-existing, unrelated. I used the `EnvSample.swift` template locally; my tests make no network calls.

## Not verified

Superseded — dev is healthy again (inbox-dev `UPDATE_COMPLETE`, ws-api task def rev 52, 1/1 running). The earlier blocker was not what I first diagnosed: the working `DRAGONFLY_API_KEY` lives in 1Password, and the `/courier/dev/dragonfly/*` entries in SSM/Secrets Manager describe a *different* Dragonfly instance than dev dials, which is why they returned `WRONGPASS` rather than being merely stale. The C-19789 `trackingIds` lift is now confirmed on a live dev socket end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
